### PR TITLE
Fix number spelling

### DIFF
--- a/ckanext/afucn/templates/group/read.html
+++ b/ckanext/afucn/templates/group/read.html
@@ -52,7 +52,7 @@
             {% snippet 'visual_snippets/gdp_trend_chart.html',
                        instance_id=gdp_trend_chart_id,
                        dataset_slug=gdp_dataset_slug,
-                       title=_('GDP Current Health Expenditure'),
+                       title=_('Health Expenditure as a proportion of GDP'),
                        group_dict=group_dict %}
           </div>
           {% endif %}

--- a/ckanext/afucn/templates/group/snippets/location_stats.html
+++ b/ckanext/afucn/templates/group/snippets/location_stats.html
@@ -90,11 +90,11 @@
     // Function to format the number dynamically based on its value
     function formatNumber(value) {
         if (value >= 1e9) {
-            return (value / 1e9).toFixed(2) + ' Billions'; // For billions
+            return (value / 1e9).toFixed(2) + ' Billion'; // For billion
         } else if (value >= 1e6) {
-            return (value / 1e6).toFixed(2) + ' Millions'; // For millions
+            return (value / 1e6).toFixed(2) + ' Million'; // For million
         } else if (value >= 1e3) {
-            return (value / 1e3).toFixed(2) + ' Thousands'; // For thousands
+            return (value / 1e3).toFixed(2) + ' Thousand'; // For thousand
         } else {
             return value.toFixed(2); // For numbers less than 1000
         }

--- a/ckanext/afucn/templates/group/snippets/location_stats.html
+++ b/ckanext/afucn/templates/group/snippets/location_stats.html
@@ -57,7 +57,7 @@
 
       <!-- GDP Per Capita -->
       <div class="key-figure-card">
-        <div class="indicator-title">GDP per capita, PPP</div>
+        <div class="indicator-title">GDP per capita, PPP (USD)</div>
         <div class="indicator-value" id="gdpPerCapita">Loading...</div>
         <div class="indicator-meta">
           <div class="source">

--- a/ckanext/afucn/templates/visual_snippets/gdp_trend_chart.html
+++ b/ckanext/afucn/templates/visual_snippets/gdp_trend_chart.html
@@ -1,7 +1,7 @@
-{#- GDP Current Health Expenditure Trend Chart Snippet
+{#- Health Expenditure as a proportion of GDP Trend Chart Snippet
 
   Extends the base echart_viz snippet to create a trend chart for
-  GDP Current Health Expenditure (%).
+  Health Expenditure as a proportion of GDP (%).
   Assumes the data has 'TimeDim' and 'NumericValue' columns.
 
   Args:
@@ -9,7 +9,7 @@
     iso_code (str): The ISO code (or other value for SpatialDim) to filter by.
                     Defaults to the `group_dict.name` if available in context.
     dataset_slug (str): Dataset slug.
-    title (str, optional): Chart title. Defaults to 'GDP Current Health Expenditure Trend for [iso_code]'.
+    title (str, optional): Chart title. Defaults to 'Health Expenditure as a proportion of GDP Trend for [iso_code]'.
     css_class (str, optional): Additional CSS classes.
     chart_height (str, optional): Chart height.
 
@@ -20,9 +20,9 @@
 
 {# --- Default Parameter Values --- #}
 {% set country_code = iso_code or group_dict.name %}
-{% set default_title = _('GDP Current Health Expenditure') %}
+{% set default_title = _('Health Expenditure as a proportion of GDP') %}
 {% if country_code %}
-  {% set default_title = _('GDP Current Health Expenditure for ') ~ country_code %}
+  {% set default_title = _('Health Expenditure as a proportion of GDP for ') ~ country_code %}
 {% endif %}
 
 {# --- Override Base Snippet Variables --- #}


### PR DESCRIPTION
- Fix number spelling
- Add currency in GDP info in countries (locations) page
- Change GDP current health expenditure – to  “Health Expenditure as a proportion of GDP”