### PR TITLE
Disable Google tag from main extension

### DIFF
--- a/ckanext/afucn/templates/base.html
+++ b/ckanext/afucn/templates/base.html
@@ -27,9 +27,11 @@
   <script src="{{ url_for('static', filename='js/walden.js') }}"></script>
 {% endblock %}
 
+{# Temporary disable google tag from main theme
 {% block htmltag %}
   {{ super() }}
     {% block googletag %}
         {% include 'snippets/google_tag.html' %}
     {% endblock %}
 {% endblock %}
+#}


### PR DESCRIPTION
Disable Google tag from main extension because ckanext-googleanalytics will be added